### PR TITLE
fix graceful shutdown of micro.

### DIFF
--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -1,7 +1,11 @@
 class MemoryStore {
   constructor (clearPeriod) {
     this.hits = new Map()
-    setInterval(this.reset.bind(this), clearPeriod)
+    let interval = setInterval(this.reset.bind(this), clearPeriod)
+    const shutdown = () => clearInterval(interval)
+    process.on('SIGINT', shutdown)
+    process.on('SIGTERM', shutdown)
+    process.on('exit', shutdown)
   }
 
   incr (key) {


### PR DESCRIPTION
Since this middleware uses `setInterval` to clear the hits, it blocks Node from exiting cleanly upon CTRL+C, server shutdown or similar. So running `micro` and then using CTRL+C will leave the terminal hanging on `micro: Gracefully shutting down. Please wait...`.

This PR fixes that.